### PR TITLE
Add Part-ID search option for parts

### DIFF
--- a/src/Controller/PartListsController.php
+++ b/src/Controller/PartListsController.php
@@ -306,6 +306,7 @@ class PartListsController extends AbstractController
         $filter->setStorelocation($request->query->getBoolean('storelocation'));
         $filter->setComment($request->query->getBoolean('comment'));
         $filter->setIPN($request->query->getBoolean('ipn'));
+        $filter->setID($request->query->getBoolean('id'));
         $filter->setOrdernr($request->query->getBoolean('ordernr'));
         $filter->setSupplier($request->query->getBoolean('supplier'));
         $filter->setManufacturer($request->query->getBoolean('manufacturer'));

--- a/templates/components/search.macro.html.twig
+++ b/templates/components/search.macro.html.twig
@@ -36,6 +36,10 @@
                     <label for="search_comment" class="form-check-label justify-content-start">{% trans %}comment.label{% endtrans %}</label>
                 </div>
                 <div class="form-check">
+                    <input type="checkbox" class="form-check-input" id="search_id" name="id" value="1" {{ stimulus_controller('elements/localStorage_checkbox') }}>
+                    <label for="search_id" class="form-check-label justify-content-start">{% trans %}id.label{% endtrans %}</label>
+                </div>
+                <div class="form-check">
                     <input type="checkbox" class="form-check-input" id="search_ipn" name="ipn" value="1" checked {{ stimulus_controller('elements/localStorage_checkbox') }}>
                     <label for="search_ipn" class="form-check-label justify-content-start">{% trans %}part.edit.ipn{% endtrans %}</label>
                 </div>

--- a/templates/parts/lists/search_list.html.twig
+++ b/templates/parts/lists/search_list.html.twig
@@ -49,6 +49,14 @@
                         <label class="form-check-label justify-content-start">{% trans %}comment.label{% endtrans %}</label>
                     </div>
                     <div class="form-check">
+                        <input type="checkbox" class="form-check-input" disabled {% if searchFilter.id %}checked{% endif %}>
+                        <label class="form-check-label justify-content-start">{% trans %}id.label{% endtrans %}</label>
+                    </div>
+                    <div class="form-check">
+                        <input type="checkbox" class="form-check-input" disabled {% if searchFilter.ipn %}checked{% endif %}>
+                        <label class="form-check-label justify-content-start">{% trans %}part.edit.ipn{% endtrans %}</label>
+                    </div>
+                    <div class="form-check">
                         <input type="checkbox" class="form-check-input" disabled {% if searchFilter.ordernr %}checked{% endif %}>
                         <label for="search_supplierpartnr" class="form-check-label justify-content-start">{% trans %}orderdetails.edit.supplierpartnr{% endtrans %}</label>
                     </div>


### PR DESCRIPTION
## Summary
- allow searching for parts by numeric database ID
- expose Part-ID toggle in global search options

## Testing
- `./vendor/bin/phpunit` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6897617c8c2c832fa1c0bc4b36d06b5e